### PR TITLE
Sonarcloud

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,6 @@
         <sonar.organization>anderson92zolis</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
 
-       <sonar.coverage.jacoco.xmlReportPaths>
-               ../app-ecommerceChallenge/target/site/jacoco-aggregate/jacoco.xml
-       </sonar.coverage.jacoco.xmlReportPaths>
-
 
    </properties>
 


### PR DESCRIPTION
By default the generated report will be saved under target/site/jacoco/jacoco.xml. This location will be checked automatically by the scanner, so no further configuration is required. Just launch: 